### PR TITLE
Add Control-C handler to manage interrupt signal

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,26 @@
-#include "HttpHandler.h"
 #include "CommandProcessor.h" // Include the header file for CommandProcessor
 #include <iostream>
 #include <string>
 #include <Windows.h>
 
+// Control-C Handler
+BOOL WINAPI CtrlHandler(DWORD fdwCtrlType) {
+    switch (fdwCtrlType) {
+    case CTRL_C_EVENT:
+        std::cout << "Control-C pressed, but ignored." << std::endl;
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
 int main() {
+
+    if (!SetConsoleCtrlHandler(CtrlHandler, TRUE)) {
+        std::cerr << "Error: Could not set control handler." << std::endl;
+        return -1;
+    }
+
     CommandProcessor commandProcessor;
     commandProcessor.start();
 


### PR DESCRIPTION
The code now includes a Control-C handler to manage the Control-C (interrupt) signal. This is done by defining a `CtrlHandler` function that handles the `CTRL_C_EVENT` by printing a message and returning `TRUE` to indicate the event was handled. For other control events, it returns `FALSE`. The `SetConsoleCtrlHandler` function is then used in the `main` function to set this handler. If setting the handler fails, an error message is printed and the program exits with a return code of `-1`.